### PR TITLE
Fixed ECMC version to 6.x between rust-ssvm and ecmc binding

### DIFF
--- a/sewup/Cargo.toml
+++ b/sewup/Cargo.toml
@@ -25,8 +25,8 @@ cryptoxide = "0.3.3"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ethereum-types = {features = ["serialize"], git = "https://github.com/paritytech/parity-common.git", rev = "0867e488f6567e0d7fe13e78a14797ff019033f7" }
 contract-address = {git = "https://github.com/paritytech/parity-common.git", rev = "0867e488f6567e0d7fe13e78a14797ff019033f7" }
-evmc-sys = { git = "https://github.com/second-state/evmc", tag = "v7.4.0-rust-evmc-client-rc.2" }
-rust-ssvm = { git = "https://github.com/second-state/rust-ssvm.git", rev = "5b37140a2e573aef62dde6a68003b1d51faeef77" }
+evmc-sys = { version = "6.3.1-rc4", package = "ssvm-evmc-sys" }
+rust-ssvm = "0.1.0-rc2"
 
 [build-dependencies]
 cmake = "0.1.42"

--- a/sewup/src/runtimes/test.rs
+++ b/sewup/src/runtimes/test.rs
@@ -157,19 +157,8 @@ impl HostContext for TestHost {
     fn selfdestruct(&mut self, addr: &[u8; 20], beneficiary: &[u8; 20]) {}
 
     #[allow(clippy::type_complexity)]
-    fn get_tx_context(
-        &mut self,
-    ) -> (
-        [u8; 32],
-        [u8; 20],
-        [u8; 20],
-        i64,
-        i64,
-        i64,
-        [u8; 32],
-        [u8; 32],
-    ) {
-        ([0; 32], [0; 20], [0; 20], 0, 0, 0, [0; 32], [0; 32])
+    fn get_tx_context(&mut self) -> ([u8; 32], [u8; 20], [u8; 20], i64, i64, i64, [u8; 32]) {
+        ([0; 32], [0; 20], [0; 20], 0, 0, 0, [0; 32])
     }
 
     fn get_block_hash(&mut self, number: i64) -> [u8; 32] {


### PR DESCRIPTION
Verify done in all `example/*`.
Prefer merge option use `rebase and merge`.

By the way, if error `"Blocking waiting for file lock on the registry index” after building parity from source` happened, need 
```bash
rm -rf ~/.cargo/registry/index/*.
```
[Ref to stackoverflow](https://stackoverflow.com/questions/47565203/cargo-build-hangs-with-blocking-waiting-for-file-lock-on-the-registry-index-a)