### PR TITLE
Implement EwasmAnyTrait

### DIFF
--- a/examples/rusty-contract/src/lib.rs
+++ b/examples/rusty-contract/src/lib.rs
@@ -11,15 +11,15 @@ struct SimpleStruct {
 fn constructor() {}
 
 #[ewasm_fn(4a6f7679)]
-fn check_input_object(s: SimpleStruct) -> Result<(), &'static str> {
+fn check_input_object(s: SimpleStruct) -> Result<sewup::primitives::EwasmAny, &'static str> {
     if !s.trust {
         return Err("NotTrustedInput");
     }
-    Ok(())
+    Ok(().into())
 }
 
 #[ewasm_main(rusty)]
-fn main() -> Result<(), &'static str> {
+fn main() -> Result<sewup::primitives::EwasmAny, &'static str> {
     use sewup::primitives::Contract;
     use sewup_derive::ewasm_input_from;
 
@@ -34,7 +34,7 @@ fn main() -> Result<(), &'static str> {
         _ => return Err("UnknownHandle"),
     };
 
-    Ok(())
+    Ok(().into())
 }
 
 #[ewasm_test]
@@ -67,11 +67,11 @@ mod tests {
 
         simple_struct.trust = true;
 
-        // use `ewasm_assert_rusty_ok`, because the `#[ewasm_main(rusty)]` specify the rusty return
-        ewasm_rusty_assert_ok!(check_input_object(simple_struct));
-
         // Assert an ok result with raw output,
         // the previous `ewasm_assert_rusty_ok` is the suggested way
-        ewasm_assert_eq!(check_input_object(simple_struct), vec![0, 0, 0, 0]);
+        ewasm_assert_eq!(
+            check_input_object(simple_struct),
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
     }
 }

--- a/sewup-derive/src/lib.rs
+++ b/sewup-derive/src/lib.rs
@@ -177,6 +177,23 @@ pub fn ewasm_main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             }
         },
+        "rusty" if Some("EwasmAny".to_string()) == output_type  => quote! {
+            #[cfg(target_arch = "wasm32")]
+            use sewup::bincode;
+            #[cfg(target_arch = "wasm32")]
+            use sewup::ewasm_api::finish_data;
+            #[cfg(all(not(target_arch = "wasm32"), not(test)))]
+            pub fn main() {}
+            #[cfg(target_arch = "wasm32")]
+            #[cfg(not(any(feature = "constructor", feature = "constructor-test")))]
+            #[no_mangle]
+            pub fn main() {
+                #input
+                let r = #name().map(|any| any.bin);
+                let bin = bincode::serialize(&r).expect("The resuslt of `ewasm_main` should be serializable");
+                finish_data(&bin);
+            }
+        },
 
         // Return all result structure
         // This is for a scenario that you are using a rust client to operation the contract

--- a/sewup/src/primitives.rs
+++ b/sewup/src/primitives.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize};
 #[cfg(target_arch = "wasm32")]
 use std::convert::TryInto;
 
@@ -74,15 +74,9 @@ impl EwasmAny {
     }
 }
 
-trait EwasmAnyTrait: Serialize {}
-impl EwasmAnyTrait for EwasmAny {}
-
-// TODO:
-// Need negative trait bound
-// https://github.com/rust-lang/rust/issues/42721
 impl<T> From<T> for EwasmAny
 where
-    T: EwasmAnyTrait + !EwasmAnyTrait ,
+    T: Serialize,
 {
     fn from(i: T) -> Self {
         Self {
@@ -91,14 +85,14 @@ where
     }
 }
 
-impl Serialize for EwasmAny {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.bin.serialize(serializer)
-    }
-}
+// impl Serialize for EwasmAny {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: Serializer,
+//     {
+//         self.bin.serialize(serializer)
+//     }
+// }
 
 impl<'de> Deserialize<'de> for EwasmAny {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
Let `EwasmAny` can be Serded, such that `EwasmAny` type can be used in Rusty contract.
Fix #245 