### PR TITLE
feat(erc721): implement ERC721Metadata tokenMetadata (Fixes #161)

### DIFF
--- a/asset/erc721_abi.json
+++ b/asset/erc721_abi.json
@@ -156,5 +156,24 @@
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenMetadata",
+    "outputs": [
+      {
+        "name": "_infoUrl",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/examples/erc721-contract/src/token.rs
+++ b/examples/erc721-contract/src/token.rs
@@ -28,6 +28,9 @@ fn main() -> anyhow::Result<()> {
         sewup::token::erc721::IS_APPROVED_FOR_ALL_SIG => {
             sewup::token::erc721::is_approved_for_all(&contract)
         }
+        sewup::token::erc721::TOKEN_METADATA_SIG => {
+            sewup::token::erc721::token_metadata(&contract)
+        }
         _ => (),
     };
     Ok(())

--- a/sewup-derive/src/function_tests.rs
+++ b/sewup-derive/src/function_tests.rs
@@ -7,6 +7,8 @@ fn test_function_signature() {
     assert_eq!(get_function_signature("sendMessage(string,address)"), sig);
     sig = hex!("70a08231");
     assert_eq!(get_function_signature("balanceOf(address)"), sig);
+    sig = hex!("6914db60");
+    assert_eq!(get_function_signature("tokenMetadata(uint256)"), sig);
 }
 
 #[test]

--- a/sewup/src/token/erc721.rs
+++ b/sewup/src/token/erc721.rs
@@ -18,11 +18,12 @@ pub use super::erc20::{
 #[cfg(target_arch = "wasm32")]
 use super::helpers::{
     copy_into_address, copy_into_storage_value, get_approval, get_balance, get_token_approval,
-    get_token_owner, set_approval, set_balance, set_token_approval, set_token_owner,
+    get_token_metadata, get_token_owner, set_approval, set_balance, set_token_approval,
+    set_token_metadata, set_token_owner,
 };
 
 #[cfg(target_arch = "wasm32")]
-use crate::utils::{caller, ewasm_return_bool};
+use crate::utils::{caller, ewasm_return_bool, ewasm_return_str};
 
 #[cfg(target_arch = "wasm32")]
 use bitcoin::util::uint::Uint256;
@@ -215,9 +216,18 @@ pub fn is_approved_for_all(contract: &Contract) {
     inputs=[ { "name": "_tokenId", "type": "uint256" } ],
     outputs=[ { "name": "_infoUrl", "type": "string" } ]
 )]
-pub fn token_metadata(_contract: &Contract) {
-    // TODO
-    // https://github.com/second-state/SewUp/issues/161
+pub fn token_metadata(contract: &Contract) {
+    let token_id: [u8; 32] = contract.input_data[4..36]
+        .try_into()
+        .expect("token id should be byte32");
+
+    let owner = get_token_owner(&token_id);
+    if owner == Address::default() {
+        ewasm_api::revert();
+    }
+
+    let url = get_token_metadata(&token_id);
+    ewasm_return_str(&url);
 }
 
 /// Implement ERC-721 safeTransferFrom(address,address,uint256,bytes)
@@ -263,6 +273,34 @@ pub fn mint(addr: &str, tokens: Vec<&str>) {
             .try_into()
             .expect("token id should be byte32");
         set_token_owner(&token_id, &address);
+        log4(
+            &Vec::<u8>::with_capacity(0),
+            &topic.into(),
+            &Raw::from(0u32).to_bytes32().into(),
+            &Raw::from(&address).to_bytes32().into(),
+            &token_id.into(),
+        );
+    }
+
+    set_balance(&address, &Raw::from(tokens.len()).to_bytes32().into());
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn mint_with_metadata(addr: &str, tokens: Vec<(&str, &str)>) {
+    let address = Address::from_str(addr).expect("address invalid");
+
+    let topic: [u8; 32] =
+        decode("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+            .unwrap()
+            .try_into()
+            .unwrap();
+    for (token, metadata) in tokens.iter() {
+        let token_id: [u8; 32] = decode(token)
+            .expect("token id should be hex format")
+            .try_into()
+            .expect("token id should be byte32");
+        set_token_owner(&token_id, &address);
+        set_token_metadata(&token_id, metadata);
         log4(
             &Vec::<u8>::with_capacity(0),
             &topic.into(),

--- a/sewup/src/token/helpers.rs
+++ b/sewup/src/token/helpers.rs
@@ -44,6 +44,12 @@ pub fn calculate_token_hash(token_id: &[u8; 32]) -> Vec<u8> {
     sha3_256(&token).to_vec()
 }
 
+pub fn calculate_token_metadata_hash(token_id: &[u8; 32]) -> Vec<u8> {
+    let mut token_metadata: Vec<u8> = "token metadata".as_bytes().into();
+    token_metadata.extend_from_slice(token_id);
+    sha3_256(&token_metadata).to_vec()
+}
+
 pub fn calculate_token_balance_hash(address: &[u8; 20], token_id: &[u8; 32]) -> Vec<u8> {
     let mut balance_of: Vec<u8> = "balanceOf".as_bytes().into();
     balance_of.extend_from_slice(address);
@@ -218,4 +224,51 @@ pub fn get_token_owner(token_id: &[u8; 32]) -> Address {
         .try_into()
         .expect("address should be bytes20");
     bytes20.into()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_token_metadata(_token_id: &[u8; 32], _metadata: &str) {}
+#[cfg(target_arch = "wasm32")]
+pub fn set_token_metadata(token_id: &[u8; 32], metadata: &str) {
+    let hash = calculate_token_metadata_hash(token_id);
+    let base_key = copy_into_storage_value(&hash);
+    let bytes = metadata.as_bytes();
+    let len = bytes.len();
+    let len_raw = Raw::from(len);
+    ewasm_api::storage_store(&base_key, &len_raw.to_bytes32().into());
+
+    for (i, chunk) in bytes.chunks(32).enumerate() {
+        let mut chunk_hash_input: Vec<u8> = hash.clone();
+        chunk_hash_input.extend_from_slice(&(i as u32).to_be_bytes());
+        let chunk_key = copy_into_storage_value(&sha3_256(&chunk_hash_input));
+        let chunk_raw = Raw::from(chunk);
+        ewasm_api::storage_store(&chunk_key, &chunk_raw.to_bytes32().into());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_token_metadata(_token_id: &[u8; 32]) -> String {
+    String::new()
+}
+#[cfg(target_arch = "wasm32")]
+pub fn get_token_metadata(token_id: &[u8; 32]) -> String {
+    let hash = calculate_token_metadata_hash(token_id);
+    let base_key = copy_into_storage_value(&hash);
+    let len_raw = Raw::from(ewasm_api::storage_load(&base_key).bytes);
+    let len: usize = len_raw.into();
+    if len == 0 {
+        return String::new();
+    }
+    let mut data = Vec::with_capacity(len);
+    let num_chunks = (len + 31) / 32;
+    for i in 0..num_chunks {
+        let mut chunk_hash_input: Vec<u8> = hash.clone();
+        chunk_hash_input.extend_from_slice(&(i as u32).to_be_bytes());
+        let chunk_key = copy_into_storage_value(&sha3_256(&chunk_hash_input));
+        let chunk_val = ewasm_api::storage_load(&chunk_key);
+        let remaining = len - data.len();
+        let take = std::cmp::min(remaining, 32);
+        data.extend_from_slice(&chunk_val.bytes[..take]);
+    }
+    String::from_utf8(data).unwrap_or_default()
 }

--- a/sewup/src/utils.rs
+++ b/sewup/src/utils.rs
@@ -53,7 +53,9 @@ pub fn ewasm_return(bytes: Vec<u8>) {
 pub fn ewasm_return_str(s: &str) {
     let mut output = Raw::from(32u32).as_bytes().to_vec();
     output.append(&mut Raw::from(s.len()).as_bytes().to_vec());
-    output.append(&mut Raw::from(s).as_bytes().to_vec());
+    for chunk in s.as_bytes().chunks(32) {
+        output.append(&mut Raw::from(chunk).as_bytes().to_vec());
+    }
     finish_data(&output);
 }
 


### PR DESCRIPTION
## Description
This PR resolves issue #161 by implementing `ERC721Metadata` support (`tokenMetadata` function) in SewUp:

- **ERC721 Metadata Implementation**: Implemented `token_metadata(contract: &Contract)` with function selector `6914db60` returning dynamic ABI v2 string URLs.
- **Validation**: Added non-existent token check reverting when queried tokens do not exist (`owner == Address::default()`).
- **Storage Helpers**: Added `calculate_token_metadata_hash`, `set_token_metadata`, and `get_token_metadata` in `sewup::token::helpers` to store and retrieve arbitrarily long metadata strings using 32-byte chunks.
- **Mint Helper**: Added `mint_with_metadata(addr, tokens)` in `sewup::token::erc721` to allow setting token metadata URLs during contract initialization.
- **ABI & String Serialization**: Enhanced `ewasm_return_str` in `sewup::utils` to handle arbitrary length strings, updated `asset/erc721_abi.json`, and added function selector test in `sewup-derive`.

Fixes #161.

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`