### PR TITLE
refactor(runtimes): re-export evmc-sys via rust-ssvm and remove redundant dependency (Fixes #276)

### DIFF
--- a/sewup/Cargo.toml
+++ b/sewup/Cargo.toml
@@ -28,7 +28,6 @@ remain = "0.2"
 paste = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-evmc-sys = { version = "6.3.1-rc4", package = "ssvm-evmc-sys" }
 rust-ssvm = "0.1.0-rc2"
 
 [build-dependencies]

--- a/sewup/src/runtimes/mod.rs
+++ b/sewup/src/runtimes/mod.rs
@@ -7,3 +7,5 @@ pub mod traits;
 
 #[allow(dead_code)]
 pub mod handler;
+
+pub use rust_ssvm::types::ffi;

--- a/sewup/src/runtimes/test.rs
+++ b/sewup/src/runtimes/test.rs
@@ -7,8 +7,10 @@ use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 
 use anyhow::Result;
-use evmc_sys::{evmc_call_kind, evmc_revision, evmc_status_code, evmc_storage_status};
 use hex::encode;
+use rust_ssvm::types::ffi::{
+    evmc_call_kind, evmc_revision, evmc_status_code, evmc_storage_status,
+};
 use rust_ssvm::{create as create_vm, host::HostContext, EvmcVm};
 
 pub struct TestRuntime {

--- a/sewup/src/runtimes/traits.rs
+++ b/sewup/src/runtimes/traits.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use evmc_sys::evmc_call_kind;
+use rust_ssvm::types::ffi::evmc_call_kind;
 use thiserror::Error;
 
 use crate::types::Raw;


### PR DESCRIPTION
## Description
This PR resolves #276 by refactoring how `evmc-sys` is consumed in `sewup`.

Previously, `sewup/Cargo.toml` maintained a duplicate direct dependency on `ssvm-evmc-sys` (`evmc-sys = { version = "6.3.1-rc4", package = "ssvm-evmc-sys" }`) alongside `rust-ssvm = "0.1.0-rc2"`.

Because `rust-ssvm` re-exports `evmc_client::*` which exports `types::ffi` (`evmc_sys`), `sewup` can cleanly consume `evmc_call_kind`, `evmc_revision`, `evmc_status_code`, and `evmc_storage_status` through `rust_ssvm::types::ffi` and re-export `ffi` at `sewup::runtimes::ffi`.

### Stipulation & Acceptance Checklist
- [x] Refactor `ssvm-evmc-client` / `rust-ssvm` dependency usage in `sewup`
- [x] Access `evmc-sys` types via `rust_ssvm::types::ffi`
- [x] Remove redundant direct `ssvm-evmc-sys` dependency from `sewup/Cargo.toml`
- [x] Re-export `ffi` under `sewup::runtimes` for downstream compatibility
- [x] Fixes #276

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`