### PR TITLE
feat(erc721): implement ERC721Enumerable tokenByIndex (Fixes #304)

### DIFF
--- a/asset/erc721_abi.json
+++ b/asset/erc721_abi.json
@@ -156,5 +156,24 @@
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [
+      {
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/examples/erc721-contract/src/token.rs
+++ b/examples/erc721-contract/src/token.rs
@@ -28,6 +28,10 @@ fn main() -> anyhow::Result<()> {
         sewup::token::erc721::IS_APPROVED_FOR_ALL_SIG => {
             sewup::token::erc721::is_approved_for_all(&contract)
         }
+        sewup::token::erc721::TOTAL_SUPPLY_SIG => sewup::token::erc721::total_supply(&contract),
+        sewup::token::erc721::TOKEN_BY_INDEX_SIG => {
+            sewup::token::erc721::token_by_index(&contract)
+        }
         _ => (),
     };
     Ok(())
@@ -37,7 +41,9 @@ fn main() -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use hex_literal::hex;
-    use sewup::erc721::{BALANCE_OF_SIG, OWNER_OF_SIG, TRANSFER_SIG};
+    use sewup::erc721::{
+        BALANCE_OF_SIG, OWNER_OF_SIG, TOKEN_BY_INDEX_SIG, TOTAL_SUPPLY_SIG, TRANSFER_SIG,
+    };
     use sewup_derive::ewasm_assert_eq;
 
     #[ewasm_test]
@@ -56,6 +62,23 @@ mod tests {
         let token1 = hex!("0000000000000000000000000000000000000000000000000000000000000001");
         let token2 = hex!("0000000000000000000000000000000000000000000000000000000000000002");
         let token4 = hex!("0000000000000000000000000000000000000000000000000000000000000004");
+
+        let index0 = hex!("0000000000000000000000000000000000000000000000000000000000000000");
+        let index1 = hex!("0000000000000000000000000000000000000000000000000000000000000001");
+        let index2 = hex!("0000000000000000000000000000000000000000000000000000000000000002");
+
+        ewasm_assert_eq!(
+            token_by_index(index0),
+            token1.to_vec()
+        );
+        ewasm_assert_eq!(
+            token_by_index(index1),
+            token2.to_vec()
+        );
+        ewasm_assert_eq!(
+            token_by_index(index2),
+            hex!("0000000000000000000000000000000000000000000000000000000000000003").to_vec()
+        );
 
         ewasm_assert_eq!(
             owner_of(token1),

--- a/sewup-derive/src/function_tests.rs
+++ b/sewup-derive/src/function_tests.rs
@@ -7,6 +7,8 @@ fn test_function_signature() {
     assert_eq!(get_function_signature("sendMessage(string,address)"), sig);
     sig = hex!("70a08231");
     assert_eq!(get_function_signature("balanceOf(address)"), sig);
+    sig = hex!("4f6ccce7");
+    assert_eq!(get_function_signature("tokenByIndex(uint256)"), sig);
 }
 
 #[test]

--- a/sewup/src/token/erc721.rs
+++ b/sewup/src/token/erc721.rs
@@ -11,14 +11,16 @@ use crate::types::Raw;
 use sewup_derive::ewasm_lib_fn;
 
 pub use super::erc20::{
-    balance_of, name, symbol, BALANCE_OF_ABI, BALANCE_OF_SIG, NAME_ABI, NAME_SIG, SYMBOL_ABI,
-    SYMBOL_SIG,
+    balance_of, name, symbol, total_supply, BALANCE_OF_ABI, BALANCE_OF_SIG, NAME_ABI, NAME_SIG,
+    SYMBOL_ABI, SYMBOL_SIG, TOTAL_SUPPLY_ABI, TOTAL_SUPPLY_SIG,
 };
 
 #[cfg(target_arch = "wasm32")]
 use super::helpers::{
-    copy_into_address, copy_into_storage_value, get_approval, get_balance, get_token_approval,
-    get_token_owner, set_approval, set_balance, set_token_approval, set_token_owner,
+    copy_into_address, copy_into_storage_value, get_approval, get_balance, get_owner_token_by_index,
+    get_token_approval, get_token_by_index, get_token_owner, get_total_supply, set_approval,
+    set_balance, set_owner_token_by_index, set_token_approval, set_token_by_index, set_token_owner,
+    set_total_supply,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -248,6 +250,26 @@ pub fn safe_transfer_from(_contract: &Contract) {
     // https://github.com/second-state/SewUp/issues/160
 }
 
+/// Implement ERC-721 Enumerable tokenByIndex(uint256)
+#[ewasm_lib_fn("4f6ccce7",
+    constant=true,
+    inputs=[{ "name": "_index", "type": "uint256" }],
+    outputs=[{ "name": "_tokenId", "type": "uint256" }]
+)]
+pub fn token_by_index(contract: &Contract) {
+    let index: [u8; 32] = contract.input_data[4..36]
+        .try_into()
+        .expect("index should be byte32");
+
+    let supply = get_total_supply();
+    if index >= supply {
+        ewasm_api::revert();
+    }
+
+    let token_id = get_token_by_index(&index);
+    ewasm_api::finish_data(&token_id.to_vec());
+}
+
 #[cfg(target_arch = "wasm32")]
 pub fn mint(addr: &str, tokens: Vec<&str>) {
     let address = Address::from_str(addr).expect("address invalid");
@@ -257,12 +279,15 @@ pub fn mint(addr: &str, tokens: Vec<&str>) {
             .unwrap()
             .try_into()
             .unwrap();
-    for token in tokens.iter() {
+    for (i, token) in tokens.iter().enumerate() {
         let token_id: [u8; 32] = decode(token)
             .expect("token id should be hex format")
             .try_into()
             .expect("token id should be byte32");
         set_token_owner(&token_id, &address);
+        let idx_bytes = Raw::from(i as u32).to_bytes32();
+        set_token_by_index(&idx_bytes, &token_id);
+        set_owner_token_by_index(&address, &idx_bytes, &token_id);
         log4(
             &Vec::<u8>::with_capacity(0),
             &topic.into(),
@@ -273,4 +298,5 @@ pub fn mint(addr: &str, tokens: Vec<&str>) {
     }
 
     set_balance(&address, &Raw::from(tokens.len()).to_bytes32().into());
+    set_total_supply(&Raw::from(tokens.len() as u32).to_bytes32());
 }

--- a/sewup/src/token/helpers.rs
+++ b/sewup/src/token/helpers.rs
@@ -219,3 +219,92 @@ pub fn get_token_owner(token_id: &[u8; 32]) -> Address {
         .expect("address should be bytes20");
     bytes20.into()
 }
+
+pub fn calculate_total_supply_hash() -> Vec<u8> {
+    sha3_256("totalSupply".as_bytes()).to_vec()
+}
+
+pub fn calculate_token_by_index_hash(index: &[u8; 32]) -> Vec<u8> {
+    let mut key: Vec<u8> = "tokenByIndex".as_bytes().into();
+    key.extend_from_slice(index);
+    sha3_256(&key).to_vec()
+}
+
+pub fn calculate_owner_token_index_hash(address: &[u8; 20], index: &[u8; 32]) -> Vec<u8> {
+    let mut key: Vec<u8> = "ownerTokenIndex".as_bytes().into();
+    key.extend_from_slice(address);
+    key.extend_from_slice(index);
+    sha3_256(&key).to_vec()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_total_supply() -> [u8; 32] {
+    [0u8; 32]
+}
+#[cfg(target_arch = "wasm32")]
+pub fn get_total_supply() -> [u8; 32] {
+    let hash = calculate_total_supply_hash();
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    ewasm_api::storage_load(&storage_key).bytes
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_total_supply(_supply: &[u8; 32]) {}
+#[cfg(target_arch = "wasm32")]
+pub fn set_total_supply(supply: &[u8; 32]) {
+    let hash = calculate_total_supply_hash();
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    let mut storage_value = StorageKey::default();
+    storage_value.bytes.copy_from_slice(supply);
+    ewasm_api::storage_store(&storage_key, &storage_value);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_token_by_index(_index: &[u8; 32]) -> [u8; 32] {
+    [0u8; 32]
+}
+#[cfg(target_arch = "wasm32")]
+pub fn get_token_by_index(index: &[u8; 32]) -> [u8; 32] {
+    let hash = calculate_token_by_index_hash(index);
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    ewasm_api::storage_load(&storage_key).bytes
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_token_by_index(_index: &[u8; 32], _token_id: &[u8; 32]) {}
+#[cfg(target_arch = "wasm32")]
+pub fn set_token_by_index(index: &[u8; 32], token_id: &[u8; 32]) {
+    let hash = calculate_token_by_index_hash(index);
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    let mut storage_value = StorageKey::default();
+    storage_value.bytes.copy_from_slice(token_id);
+    ewasm_api::storage_store(&storage_key, &storage_value);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_owner_token_by_index(_address: &Address, _index: &[u8; 32]) -> [u8; 32] {
+    [0u8; 32]
+}
+#[cfg(target_arch = "wasm32")]
+pub fn get_owner_token_by_index(address: &Address, index: &[u8; 32]) -> [u8; 32] {
+    let hash = calculate_owner_token_index_hash(&address.inner.bytes, index);
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    ewasm_api::storage_load(&storage_key).bytes
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn set_owner_token_by_index(_address: &Address, _index: &[u8; 32], _token_id: &[u8; 32]) {}
+#[cfg(target_arch = "wasm32")]
+pub fn set_owner_token_by_index(address: &Address, index: &[u8; 32], token_id: &[u8; 32]) {
+    let hash = calculate_owner_token_index_hash(&address.inner.bytes, index);
+    let mut storage_key = StorageKey::default();
+    storage_key.bytes.copy_from_slice(&hash[0..32]);
+    let mut storage_value = StorageKey::default();
+    storage_value.bytes.copy_from_slice(token_id);
+    ewasm_api::storage_store(&storage_key, &storage_value);
+}


### PR DESCRIPTION
## Summary
This pull request implements the ERC-721 Enumerable `tokenByIndex` function as requested in #304:
- Implemented `tokenByIndex(uint256 _index) external view returns (uint256)` (selector `0x4f6ccce7`) in `sewup/src/token/erc721.rs`.
- Added storage helper functions for total supply, global token index mapping, and owner token index mapping in `sewup/src/token/helpers.rs`.
- Updated `mint` in `sewup/src/token/erc721.rs` to track indices and total supply upon minting.
- Re-exported `total_supply`, `TOTAL_SUPPLY_ABI`, and `TOTAL_SUPPLY_SIG` in `erc721` module.
- Added ABI definitions in `asset/erc721_abi.json`.
- Updated `examples/erc721-contract/src/token.rs` with `TOKEN_BY_INDEX_SIG` routing and ewasm test assertions.
- Added signature verification unit test in `sewup-derive/src/function_tests.rs`.

Fixes #304

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`